### PR TITLE
Add post: ten PRs before lunch from my phone

### DIFF
--- a/content/posts/shipping-from-my-phone/index.md
+++ b/content/posts/shipping-from-my-phone/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Ten PRs Before Lunch, From My Phone: The Prompting That Made It Reasonable"
+title: "Ten PRs Before Lunch, From My Phone"
 date: 2026-04-26T10:00:00Z
 draft: false
 hero: images/posts/shipping-from-my-phone/hero.svg
-description: "Two hours, ten merged PRs, no editor. Just a phone, Claude Code, and six prompting patterns that turn the model from a coder into a release engineer."
+description: "Two hours, ten merged PRs, no editor. Just a phone, Claude Code, and the prompting habits that turn the model from a coder into a release engineer."
 theme: Toha
 author:
   name: Adam Brown
@@ -11,161 +11,144 @@ author:
 image_alt: "A phone on a kitchen counter showing a GitHub PR list, coffee cup beside it"
 tags: ["agentic-coding", "claude-code", "prompting", "side-projects", "productivity"]
 categories: ["Projects", "Tech"]
-summary: "Two hours, ten merged PRs, no editor. Just a phone, Claude Code, and six prompting patterns that turn the model from a coder into a release engineer."
+summary: "Two hours, ten merged PRs, no editor. Just a phone, Claude Code, and the prompting habits that turn the model from a coder into a release engineer."
 ---
 
-[Tour of the Bible](https://bible-tour.vercel.app) is a small web app that walks you through every book of the Bible in about ninety minutes. It's a side-project. I am not a frontend engineer. Every line of code in it has been written in conversational sessions with [Claude Code](https://claude.com/claude-code). The `claude/...` branch prefixes scattered through the [git history](https://github.com/adamswbrown/bible-tour) are the receipts.
+[Tour of the Bible](https://bible-tour.vercel.app) is a small web app that walks you through every book of the Bible in about ninety minutes. It's a side-project. I am not a frontend engineer. Every line of code in it has been written in conversational sessions with [Claude Code](https://claude.com/claude-code), and the `claude/...` branches scattered through the [git history](https://github.com/adamswbrown/bible-tour) are the receipts.
 
-This morning I shipped ten pull requests from my phone, in about two hours. Per-verse ESV audio across two surfaces of the app. ESV added as a reading translation. A UX fix for the Strong's word-study mode. README updates. A CHANGELOG backfilled to the project's first commit. I never opened an editor.
+This morning I shipped ten pull requests from my phone, in about two hours. Per-verse ESV audio across two surfaces of the app. ESV added as a reading translation. A UX fix for the Strong's word-study mode. A README rewrite. A CHANGELOG backfilled to the project's first commit. I never opened an editor.
 
-This post isn't really about what I shipped. It's about the *prompting* that made shipping it from a phone reasonable instead of ridiculous. Six patterns. They're worth more than any specific model or tool.
+The interesting part isn't *what* I shipped. It's how I prompted, and why prompting that way made phone-based shipping reasonable instead of ridiculous. Six habits. They matter more than any particular model or tool.
 
-## The setup: what is Claude actually doing?
+## What is Claude actually doing here?
 
-It's worth being explicit about the division of labour here, because the honest answer changes how you prompt.
+Worth being explicit about who's doing what, because the honest answer changes how you prompt.
 
-| My job | Claude's job |
-|---|---|
-| Product direction | Research |
-| Scope decisions | Implementation |
-| UX taste | Git mechanics, PR + CI orchestration |
-| Knowing what's worth building | Knowing how to build it |
-| Saying *"ship it"* | Saying *"here's what you'd give up"* |
+I'm doing product direction, scope decisions, and UX taste. I'm the one who knows what's worth building and the one who eventually says "ship it". Claude is doing research, implementation, the mechanics of git and PRs and CI, and (when I let it) telling me what I'd be giving up before I commit to anything. I make the calls. Claude does the work and pushes back when I'm wrong. That's the whole contract, and the rest of this post falls out of it.
 
-I make decisions; Claude implements them and pushes back when I'm wrong. That's the contract. Every pattern below is downstream of it.
+## 1. Talk first, code last
 
-## Pattern 1. Talk first, code last
-
-The first prompt I sent this morning was, in full, six words:
+The first prompt I sent this morning was, in full, six words.
 
 > *"Research audio bible api options."*
 
 No spec. No solution. No file paths. Just a direction.
 
-Six words bought me a survey of every realistic option in the space. Bible Brain. API.Bible. The YouVersion developer API, which, as it turns out, has no audio endpoint at all. Surprise. The eBible.org public-domain WEB recordings. The [Zaxser/verse-timings](https://github.com/Zaxser/verse-timings) forced-alignment data set. The Crossway ESV API. Each one came back with licensing terms, rate limits, and a verdict.
+Six words bought me a survey of every realistic option in the space. Bible Brain. API.Bible. The YouVersion developer API, which, as it turns out, has no audio endpoint at all (mild surprise, that one). The eBible.org public-domain WEB recordings. The [Zaxser/verse-timings](https://github.com/Zaxser/verse-timings) forced-alignment dataset. Crossway's ESV API. Each came back with licensing terms, rate limits, and a verdict.
 
-If I'd opened with *"Add audio playback using the YouVersion API"* I'd have wasted half an hour discovering that endpoint doesn't exist. Open prompts produce better research than narrow ones, because they give the model permission to disagree with your premise *before* it touches any code.
+If I'd opened with *"Add audio playback using the YouVersion API"* I'd have spent half an hour discovering that the endpoint doesn't exist. Open prompts produce better research than narrow ones, because they give the model permission to disagree with your premise before it touches any code.
 
 The cheapest line of code is the one you decided not to write.
 
-## Pattern 2. Devil's advocate as a service
+## 2. Devil's advocate as a service
 
-This is the highest-leverage prompt I know. I'll give you the wording verbatim, because it matters:
+This is the prompt I get the most out of, and the wording matters, so I'll give it to you verbatim.
 
 > *"Play devil's advocate around the idea of full translation support for the audio. If that's going to add a level of complexity I can't really support, convince me of my options."*
 
 I had a goal already. Per-verse audio playback that matched whichever translation the user had picked: NIV, NIrV, NIVUK, KJV, WEB, ASV. It felt right. It mirrored the existing text experience. I half-believed in it.
 
-Five points came back, and the goal collapsed in the time it took to read them:
+Five points came back, and the goal collapsed in the time it took to read them.
 
-1. **NIV/NIrV/NIVUK can't be embedded legally.** Biblica doesn't licence audio for third-party players at any free tier. Translation parity was already impossible. Anything I built was going to be a hybrid the moment it touched the licensed translations.
-2. **Listeners don't pick translations the way readers do.** Translation choice is a *reading* decision. When you press play you mostly want a clear voice reading the words.
-3. **Audio is supplemental in this app, not the headline.** The product is a 90-minute reading checklist. Audio is a convenience layer on top.
-4. **Each translation is recurring engineering for marginal value.** Sourcing, licensing, hosting, maintaining when sources move. Per-translation cost, marginal user value.
-5. **WEB and KJV cover ~90% of what a casual listener actually wants.**
+1. NIV/NIrV/NIVUK can't be embedded legally. Biblica doesn't licence audio for third-party players at any free tier. Translation parity was already impossible. Anything I built was going to be a hybrid the moment it touched the licensed translations.
+2. Listeners don't pick translations the way readers do. Translation choice is a *reading* decision. When you press play you mostly want a clear voice reading the words.
+3. Audio is supplemental in this app. The product is a 90-minute reading checklist; audio is a convenience layer on top.
+4. Each translation is recurring engineering work for marginal value. Sourcing, licensing, hosting, fixing it when sources move. Per-translation cost, per-translation maintenance, per-translation nothing-much.
+5. WEB and KJV cover most of what a casual listener actually wants.
 
-Days of integration work I won't do, plus a version of the feature that actually ships.
+That's days of integration work I won't do, plus a version of the feature that actually ships.
 
-The trick isn't asking the model to validate you. It's asking it to argue *against* you. *"Convince me of my options"* forces an opinionated counter-proposal instead of a polite pros-and-cons list. I now keep this prompt in my head for any feature larger than an afternoon's work. It catches premise-level mistakes that no amount of careful implementation can fix.
+The trick isn't asking the model to validate you. It's asking it to argue against you. *"Convince me of my options"* forces an opinionated counter-proposal instead of a polite pros-and-cons list. I keep this one in my head for any feature larger than an afternoon's work, because it catches the kind of premise mistake that no amount of careful implementation can fix.
 
-## Pattern 3. Make "easy" a first-class requirement
+## 3. Make "easy" a first-class requirement
 
-I asked for the **easiest** option three times this morning, not the best. That word is doing a lot of work.
+I asked for the *easiest* option three times this morning, not the best. That word does a lot of work.
 
-When you ask for the *best* path you get a menu. When you ask for the *easiest* you get a recommendation. The constraint forces an opinion.
+Ask for the *best* path and you get a menu. Ask for the *easiest* and you get a recommendation. The constraint forces an opinion.
 
-Here's what "easiest" ruled out for me, in one move:
+Here's what "easiest" ruled out for me, in one move.
 
 - Forced alignment of chapter MP3s to extract per-verse clips. (Possible. A week of work.)
 - Pre-slicing 234 verse-clip MP3s and bundling them with the app. (Possible. A day of work plus storage.)
 - Running multiple audio sources behind a translation-aware switch. (Possible. Hybrid UX.)
-- Using browser SpeechSynthesis as a synthetic-voice fallback. (Possible. Sounds bad on Android.)
+- Browser SpeechSynthesis as a synthetic-voice fallback. (Possible. Sounds bad on Android.)
 
-The shortlist that survived: Crossway's ESV `/v3/passage/audio/?q=ref` endpoint. One HTTP call returns a 302 to an MP3. I forward that 302 to the browser, the `<audio>` tag follows it, Crossway's CDN serves the bytes, edge cache for seven days, done. Two hours of work.
+The shortlist that survived was Crossway's ESV `/v3/passage/audio/?q=ref` endpoint. One HTTP call returns a 302 to an MP3. I forward the 302 to the browser, the `<audio>` tag follows it, Crossway's CDN serves the bytes, edge cache for seven days, done. Two hours of work.
 
-If "easy" hadn't been a first-class requirement, I'd have ended up with something more clever and less shipped.
+If "easy" hadn't been a stated requirement, I'd have ended up with something more clever and less shipped.
 
-## Pattern 4. Trust, but with named tradeoffs
+## 4. Trust, but with named tradeoffs
 
-When Claude proposes a direction, the answer to *"want me to ship?"* is *"yes"*. But only because the proposal explicitly lists what I'd be giving up.
+When Claude proposes a direction, my answer to *"want me to ship?"* is usually yes, but only because the proposal explicitly lists what I'd be giving up.
 
-Boiled down, the actual structure of a Claude proposal from this morning looked like this:
+Boiled down, the actual structure of a Claude proposal from this morning looked like this.
 
-> **Pick the ESV API.** Two-hour integration. Real human narration. Pattern matches your existing `/api/verse` proxy.
+> Pick the ESV API. Two-hour integration. Real human narration. Pattern matches your existing `/api/verse` proxy.
 >
-> **Tradeoffs:**
-> * Audio is *always ESV*, regardless of selected reading translation.
-> * Free for non-commercial only. Needs Crossway approval if you ever monetise.
-> * Adds a Crossway API key to env vars (existing YouVersion key is already in there).
+> Tradeoffs:
+> 1. Audio is always ESV, regardless of selected reading translation.
+> 2. Free for non-commercial only. Crossway approval required if you ever monetise.
+> 3. Adds a Crossway API key to env vars (the existing YouVersion key is already in there).
 
 I trust the implementation because the tradeoffs are named in advance. If they're hidden, I push back and ask for them.
 
-This is also how I catch over-engineering. If a proposal *doesn't* list any tradeoffs, that's usually a sign the model has reached for a heavier solution than the problem deserves. *"What does this give up?"* is a useful follow-up when none have been volunteered.
+It's also how I catch over-engineering. If a proposal *doesn't* list any tradeoffs, that's usually a sign the model has reached for a heavier solution than the problem deserves. *"What does this give up?"* is a good follow-up when nothing has been volunteered.
 
-## Pattern 5. Mobile-first orchestration
+## 5. Mobile-first orchestration
 
 I was on my phone all morning. No editor. No localhost. No `npm run dev`. I could read GitHub diffs in a tiny font and that was about it. So the loop had to look different from how most people use Claude.
 
 The strategy was continuous deployment plus aggressive delegation. Every PR Claude opened got merged to `main` immediately. Vercel rebuilt production within a minute. I tested on the live site, on my phone, after each merge. Real users were potentially hitting features I'd shipped sixty seconds earlier. That feels reckless until you remember the alternative is testing nothing at all.
 
-This shifted Claude into a role most people don't ask it to play: **release engineer**. Branch from latest `main`. Commit with a sensible message. Push. Open a draft PR. Watch CI. Merge once green. Unsubscribe from the PR webhook. All autonomous. I'd authorise *"push to prod"* once and Claude would handle the mechanics every time afterwards.
+This put Claude in a role most people don't ask it to play, which is release engineer. Branch from latest `main`. Commit with a sensible message. Push. Open a draft PR. Watch CI. Merge once green. Unsubscribe from the PR webhook. All autonomous. I'd authorise *"push to prod"* once and Claude would handle the mechanics every time afterwards.
 
-Claude Code's `subscribe_pr_activity` was load-bearing here. It let Claude react to every CI signal and review comment as it landed, without me babysitting GitHub. When Vercel posted a preview-ready comment, Claude triaged it ("informational only, no action") and moved on. When CI eventually goes red on something, Claude will investigate and propose a fix without me asking.
+Claude Code's `subscribe_pr_activity` was carrying a lot of weight here. It let Claude react to every CI signal and review comment as it landed, without me babysitting GitHub from my phone. When Vercel posted a preview-ready comment, Claude triaged it ("informational only, no action") and moved on. When CI eventually goes red on something, Claude will investigate and propose a fix without me asking.
 
-The implication. Claude isn't just my pair-programmer in this setup. It's my CI dashboard, my code reviewer, and my deploy bot. That's the difference between *"AI helps me write code"* and *"AI runs the loop while I make decisions."*
+Which means Claude wasn't just my pair-programmer in this setup. It was my CI dashboard, my reviewer, my deploy bot. That's the difference between AI helping you write code and AI running the loop while you make decisions, and the second one is the thing that scales to phone-only.
 
-## Pattern 6. Documentation as a deliverable
+## 6. Documentation as a deliverable
 
 I treat README and CHANGELOG updates as part of the feature, not a follow-up. Same-day docs are the only ones that ever happen on a side-project.
 
-This is also where AI assistants are uniquely good. They remember exactly what they just built. They have all the context. They'll write the README change *better* than you would, because they're working from the implementation, not from memory.
+This is also where AI assistants are unfairly good. They remember exactly what they just built. They have all the context. They will write the README change *better* than you would, because they're working from the implementation rather than from memory.
 
 Late in the session I asked Claude to backfill the CHANGELOG to project inception. That's hours of code archaeology. Walking the git log, consolidating intermediate work commits, attributing changes to the right PRs, classifying everything as Added/Changed/Removed/Fixed. One prompt, one PR, done. I'd never have done it by hand.
 
-If your AI assistant is doing the implementation but not the docs, you're leaving a lot of value on the table.
+If your assistant is doing the implementation but not the docs, you're leaving a lot of value on the table.
 
 ## The session, end to end
 
-Six patterns, applied to one morning's work. Here's the arc.
+Six habits, applied to one morning. Here's the arc.
 
-* **09:00.** *"Research audio bible api options."* Fifteen minutes later I have a survey of seven options with verdicts.
-* **09:20.** Devil's-advocate prompt kills translation parity. Goal shrinks to *"one good audio source for every reference."*
-* **09:30.** *"What's the easiest path to listen to that specific verse?"* Answer: the ESV API.
-* **09:35.** Claude scaffolds `/api/verse-audio` as a near-copy of the existing `/api/verse` proxy. Inline `<audio>` lands in the verse panel. Crossway citation rendered alongside.
-* **09:45.** Push to prod. I test on my phone. Audio works.
-* **10:00.** Realisation: the same Crossway API key powers ESV *text* at `/passage/text/`. Half-hour upgrade adds ESV as a reading translation.
-* **10:30.** UX fixes. An "ESV Audio" pill so the audio-translation contract is visible. Originals mode auto-switches the translation to KJV (Strong's tagging is KJV-only, which made the toggle look broken on ESV). ESV text omits inline `[N]` verse markers because the panel header already names the range.
-* **11:00.** Same pattern extended to the Eagle Method book pages. ESV text, plus a *toggleable* audio player. Toggle defaults off, because the page shows five-plus verse cards in a grid and always-on audio would be visual noise.
-* **11:30.** README updated. CHANGELOG started, then backfilled to project inception.
-* **11:50.** Done. Ten PRs merged: [#16](https://github.com/adamswbrown/bible-tour/pull/16) through [#25](https://github.com/adamswbrown/bible-tour/pull/25).
+At nine, I asked it to research audio Bible API options. Fifteen minutes later I had a survey of seven options with verdicts. By twenty past, the devil's-advocate prompt had killed translation parity, and the goal had shrunk to "one good audio source for every reference". By half past, the answer to "easiest path" was the ESV API.
 
-Two new API routes. One new translation. One new toggle. Zero new dependencies. Two hours.
+At twenty-five to ten Claude scaffolded `/api/verse-audio` as a near-copy of the existing `/api/verse` proxy. Inline `<audio>` landed in the verse panel. Crossway citation rendered alongside. Push to prod, and I tested on my phone. Audio worked.
 
-## What I take away from this
+Ten o'clock was the realisation that the same Crossway API key powers ESV *text* at `/passage/text/`. A half-hour upgrade later, ESV was a reading translation. By half ten the UX was tidied: an "ESV Audio" pill so users could see which translation the audio uses, an Originals-mode auto-switch to KJV (Strong's tagging is KJV-only, which had been making the toggle look broken on ESV), and the inline `[N]` verse markers stripped from the ESV text because the panel header already names the range.
 
-A few things I've come to believe after building most of an app this way.
+Eleven, the same pattern got extended to the Eagle Method book pages, with ESV text and a *toggleable* audio player. Toggle defaults to off, because the page shows five-plus verse cards in a grid and always-on audio would be visual noise.
 
-**Constraints that ship beat goals that don't.** Translation parity was the ambitious goal. One translation that works everywhere was the shipped product. That's not a compromise; it's the right answer.
+By half eleven the README was updated and the CHANGELOG had been backfilled to project inception. By ten to twelve, ten PRs were merged: [#16](https://github.com/adamswbrown/bible-tour/pull/16) through [#25](https://github.com/adamswbrown/bible-tour/pull/25). Two new API routes, one new translation, one new toggle, zero new dependencies, two hours.
 
-**Free upgrades compound.** Once the Crossway key was in production for audio, ESV text was a half-hour add. Look for these wherever an integration's surface area is small.
+## What I take from this
 
-**Toggles are a real design tool, not a hedge.** The Eagle audio toggle isn't *"we couldn't decide"*. It's the right UX for a dense grid where always-on audio would clutter the page.
+Translation parity was the ambitious goal; one translation that works everywhere was the shipped product. That isn't a compromise, it's the right answer, and that's the lesson I keep relearning: constraints that ship beat goals that don't.
 
-**Open prompts produce better research than narrow ones.** *"Research X"* gives a survey. *"Implement X"* jumps straight to code and skips the part where you decide whether X is even the right thing.
+Free upgrades compound, and you should look for them. Once the Crossway key was in production for audio, ESV text was a half-hour add. The same will be true wherever an integration's surface area is small.
 
-**Devil's advocate is the highest-ROI prompt I know.** The five points that killed my translation-parity goal would have cost me a week of work each on their own.
+Toggles are a real design tool, not a hedge. The Eagle audio toggle isn't *"we couldn't decide"*; it's the right UX for a dense grid where always-on audio would clutter the page.
 
-**Tell the model what kind of answer you want.** *"Easiest."* *"Most architecturally consistent."* *"Convince me of my options."* *"Play devil's advocate."* Constraints like these are how you get opinionated output instead of waffle.
+Open prompts produce better research than narrow ones. *"Research X"* gives a survey. *"Implement X"* jumps straight to code and skips the part where you decide whether X is even the right thing to build. And tell the model what kind of answer you want, while you're at it. *"Easiest."* *"Most architecturally consistent."* *"Convince me of my options."* *"Play devil's advocate."* That's how you get opinionated output instead of waffle.
 
-**Treat the model like a senior collaborator, not a junior coder.** Hand it scope decisions and licence to push back. It will, if you let it. Most users don't.
+Treat the model like a senior collaborator, not a junior coder. Hand it scope decisions and licence to push back. It will, if you let it. Most users don't.
 
-**Ship the docs in the same session as the code.** The model has the context; you have the momentum. Both fade fast.
+Ship the docs in the same session as the code, because the model has the context and you have the momentum, and both fade fast.
 
-**Let the model run the release loop.** PRs, CI signals, merges, Vercel deploys. None of that needs to come back to you. Subscribe to the webhook activity, set the merge policy, stay in the strategic loop.
+And let the model run the release loop. PRs, CI signals, merges, Vercel deploys; none of that needs to come back to you. Subscribe to the webhook activity, set the merge policy, and stay in the strategic loop.
 
-The meta-lesson. Building with AI doesn't mean *automating the act of coding*. Anyone can prompt for code. It means **automating the engineering loop around the coding**: research, scoping, branching, CI, deploy, docs. The only thing left for you to do is product judgement.
+The thing I've come to believe, after a few months of building this way, is that building with AI doesn't really mean *automating the act of coding*. Anyone can prompt for code. It means automating the engineering loop *around* the coding (research, scoping, branching, CI, deploy, docs) so the only thing left for you to do is product judgement.
 
-I made decisions for two hours this morning. Claude turned each decision into a shipped PR. That ratio is the real win, not the lines of code.
+I made decisions for two hours this morning. Claude turned each decision into a shipped PR. That ratio is the win, not the line count.
 
 ---
 

--- a/content/posts/shipping-from-my-phone/index.md
+++ b/content/posts/shipping-from-my-phone/index.md
@@ -3,7 +3,7 @@ title: "Ten PRs Before Lunch, From My Phone: The Prompting That Made It Reasonab
 date: 2026-04-26T10:00:00Z
 draft: false
 hero: images/posts/shipping-from-my-phone/hero.svg
-description: "Two hours, ten merged PRs, no editor — just a phone, Claude Code, and six prompting patterns that turn the model from a coder into a release engineer."
+description: "Two hours, ten merged PRs, no editor. Just a phone, Claude Code, and six prompting patterns that turn the model from a coder into a release engineer."
 theme: Toha
 author:
   name: Adam Brown
@@ -11,10 +11,10 @@ author:
 image_alt: "A phone on a kitchen counter showing a GitHub PR list, coffee cup beside it"
 tags: ["agentic-coding", "claude-code", "prompting", "side-projects", "productivity"]
 categories: ["Projects", "Tech"]
-summary: "Two hours, ten merged PRs, no editor — just a phone, Claude Code, and six prompting patterns that turn the model from a coder into a release engineer."
+summary: "Two hours, ten merged PRs, no editor. Just a phone, Claude Code, and six prompting patterns that turn the model from a coder into a release engineer."
 ---
 
-[Tour of the Bible](https://bible-tour.vercel.app) is a small web app that walks you through every book of the Bible in about ninety minutes. It's a side-project. I am not a frontend engineer. Every line of code in it has been written in conversational sessions with [Claude Code](https://claude.com/claude-code) — the `claude/...` branch prefixes scattered through the [git history](https://github.com/adamswbrown/bible-tour) are the receipts.
+[Tour of the Bible](https://bible-tour.vercel.app) is a small web app that walks you through every book of the Bible in about ninety minutes. It's a side-project. I am not a frontend engineer. Every line of code in it has been written in conversational sessions with [Claude Code](https://claude.com/claude-code). The `claude/...` branch prefixes scattered through the [git history](https://github.com/adamswbrown/bible-tour) are the receipts.
 
 This morning I shipped ten pull requests from my phone, in about two hours. Per-verse ESV audio across two surfaces of the app. ESV added as a reading translation. A UX fix for the Strong's word-study mode. README updates. A CHANGELOG backfilled to the project's first commit. I never opened an editor.
 
@@ -34,7 +34,7 @@ It's worth being explicit about the division of labour here, because the honest 
 
 I make decisions; Claude implements them and pushes back when I'm wrong. That's the contract. Every pattern below is downstream of it.
 
-## Pattern 1 — Talk first, code last
+## Pattern 1. Talk first, code last
 
 The first prompt I sent this morning was, in full, six words:
 
@@ -42,33 +42,33 @@ The first prompt I sent this morning was, in full, six words:
 
 No spec. No solution. No file paths. Just a direction.
 
-Six words bought me a survey of every realistic option in the space: Bible Brain, API.Bible, the YouVersion developer API (which, as it turns out, has no audio endpoint at all — surprise), the eBible.org public-domain WEB recordings, the [Zaxser/verse-timings](https://github.com/Zaxser/verse-timings) forced-alignment data set, the Crossway ESV API. Each one came back with licensing terms, rate limits, and a verdict.
+Six words bought me a survey of every realistic option in the space. Bible Brain. API.Bible. The YouVersion developer API, which, as it turns out, has no audio endpoint at all. Surprise. The eBible.org public-domain WEB recordings. The [Zaxser/verse-timings](https://github.com/Zaxser/verse-timings) forced-alignment data set. The Crossway ESV API. Each one came back with licensing terms, rate limits, and a verdict.
 
 If I'd opened with *"Add audio playback using the YouVersion API"* I'd have wasted half an hour discovering that endpoint doesn't exist. Open prompts produce better research than narrow ones, because they give the model permission to disagree with your premise *before* it touches any code.
 
 The cheapest line of code is the one you decided not to write.
 
-## Pattern 2 — Devil's advocate as a service
+## Pattern 2. Devil's advocate as a service
 
 This is the highest-leverage prompt I know. I'll give you the wording verbatim, because it matters:
 
 > *"Play devil's advocate around the idea of full translation support for the audio. If that's going to add a level of complexity I can't really support, convince me of my options."*
 
-I had a goal already: per-verse audio playback that matched whichever translation the user had picked — NIV, NIrV, NIVUK, KJV, WEB, ASV. It felt right. It mirrored the existing text experience. I half-believed in it.
+I had a goal already. Per-verse audio playback that matched whichever translation the user had picked: NIV, NIrV, NIVUK, KJV, WEB, ASV. It felt right. It mirrored the existing text experience. I half-believed in it.
 
 Five points came back, and the goal collapsed in the time it took to read them:
 
-1. **NIV/NIrV/NIVUK can't be embedded legally.** Biblica doesn't licence audio for third-party players at any free tier. Translation parity was already impossible — anything I built was going to be a hybrid the moment it touched the licensed translations.
+1. **NIV/NIrV/NIVUK can't be embedded legally.** Biblica doesn't licence audio for third-party players at any free tier. Translation parity was already impossible. Anything I built was going to be a hybrid the moment it touched the licensed translations.
 2. **Listeners don't pick translations the way readers do.** Translation choice is a *reading* decision. When you press play you mostly want a clear voice reading the words.
 3. **Audio is supplemental in this app, not the headline.** The product is a 90-minute reading checklist. Audio is a convenience layer on top.
-4. **Each translation is recurring engineering for marginal value.** Sourcing, licensing, hosting, maintaining when sources move — per-translation cost, marginal user value.
+4. **Each translation is recurring engineering for marginal value.** Sourcing, licensing, hosting, maintaining when sources move. Per-translation cost, marginal user value.
 5. **WEB and KJV cover ~90% of what a casual listener actually wants.**
 
 Days of integration work I won't do, plus a version of the feature that actually ships.
 
 The trick isn't asking the model to validate you. It's asking it to argue *against* you. *"Convince me of my options"* forces an opinionated counter-proposal instead of a polite pros-and-cons list. I now keep this prompt in my head for any feature larger than an afternoon's work. It catches premise-level mistakes that no amount of careful implementation can fix.
 
-## Pattern 3 — Make "easy" a first-class requirement
+## Pattern 3. Make "easy" a first-class requirement
 
 I asked for the **easiest** option three times this morning, not the best. That word is doing a lot of work.
 
@@ -85,59 +85,59 @@ The shortlist that survived: Crossway's ESV `/v3/passage/audio/?q=ref` endpoint.
 
 If "easy" hadn't been a first-class requirement, I'd have ended up with something more clever and less shipped.
 
-## Pattern 4 — Trust, but with named tradeoffs
+## Pattern 4. Trust, but with named tradeoffs
 
-When Claude proposes a direction, the answer to *"want me to ship?"* is *"yes"* — but only because the proposal explicitly lists what I'd be giving up.
+When Claude proposes a direction, the answer to *"want me to ship?"* is *"yes"*. But only because the proposal explicitly lists what I'd be giving up.
 
 Boiled down, the actual structure of a Claude proposal from this morning looked like this:
 
 > **Pick the ESV API.** Two-hour integration. Real human narration. Pattern matches your existing `/api/verse` proxy.
 >
 > **Tradeoffs:**
-> – Audio is *always ESV*, regardless of selected reading translation.
-> – Free for non-commercial only — needs Crossway approval if you ever monetise.
-> – Adds a Crossway API key to env vars (existing YouVersion key is already in there).
+> * Audio is *always ESV*, regardless of selected reading translation.
+> * Free for non-commercial only. Needs Crossway approval if you ever monetise.
+> * Adds a Crossway API key to env vars (existing YouVersion key is already in there).
 
 I trust the implementation because the tradeoffs are named in advance. If they're hidden, I push back and ask for them.
 
 This is also how I catch over-engineering. If a proposal *doesn't* list any tradeoffs, that's usually a sign the model has reached for a heavier solution than the problem deserves. *"What does this give up?"* is a useful follow-up when none have been volunteered.
 
-## Pattern 5 — Mobile-first orchestration
+## Pattern 5. Mobile-first orchestration
 
 I was on my phone all morning. No editor. No localhost. No `npm run dev`. I could read GitHub diffs in a tiny font and that was about it. So the loop had to look different from how most people use Claude.
 
 The strategy was continuous deployment plus aggressive delegation. Every PR Claude opened got merged to `main` immediately. Vercel rebuilt production within a minute. I tested on the live site, on my phone, after each merge. Real users were potentially hitting features I'd shipped sixty seconds earlier. That feels reckless until you remember the alternative is testing nothing at all.
 
-This shifted Claude into a role most people don't ask it to play — **release engineer**. Branch from latest `main`. Commit with a sensible message. Push. Open a draft PR. Watch CI. Merge once green. Unsubscribe from the PR webhook. All autonomous. I'd authorise *"push to prod"* once and Claude would handle the mechanics every time afterwards.
+This shifted Claude into a role most people don't ask it to play: **release engineer**. Branch from latest `main`. Commit with a sensible message. Push. Open a draft PR. Watch CI. Merge once green. Unsubscribe from the PR webhook. All autonomous. I'd authorise *"push to prod"* once and Claude would handle the mechanics every time afterwards.
 
 Claude Code's `subscribe_pr_activity` was load-bearing here. It let Claude react to every CI signal and review comment as it landed, without me babysitting GitHub. When Vercel posted a preview-ready comment, Claude triaged it ("informational only, no action") and moved on. When CI eventually goes red on something, Claude will investigate and propose a fix without me asking.
 
-The implication: Claude isn't just my pair-programmer in this setup. It's my CI dashboard, my code reviewer, and my deploy bot. That's the difference between *"AI helps me write code"* and *"AI runs the loop while I make decisions."*
+The implication. Claude isn't just my pair-programmer in this setup. It's my CI dashboard, my code reviewer, and my deploy bot. That's the difference between *"AI helps me write code"* and *"AI runs the loop while I make decisions."*
 
-## Pattern 6 — Documentation as a deliverable
+## Pattern 6. Documentation as a deliverable
 
 I treat README and CHANGELOG updates as part of the feature, not a follow-up. Same-day docs are the only ones that ever happen on a side-project.
 
 This is also where AI assistants are uniquely good. They remember exactly what they just built. They have all the context. They'll write the README change *better* than you would, because they're working from the implementation, not from memory.
 
-Late in the session I asked Claude to backfill the CHANGELOG to project inception. That's hours of code archaeology — walking the git log, consolidating intermediate work commits, attributing changes to the right PRs, classifying everything as Added/Changed/Removed/Fixed. One prompt, one PR, done. I'd never have done it by hand.
+Late in the session I asked Claude to backfill the CHANGELOG to project inception. That's hours of code archaeology. Walking the git log, consolidating intermediate work commits, attributing changes to the right PRs, classifying everything as Added/Changed/Removed/Fixed. One prompt, one PR, done. I'd never have done it by hand.
 
 If your AI assistant is doing the implementation but not the docs, you're leaving a lot of value on the table.
 
 ## The session, end to end
 
-Six patterns, applied to one morning's work. Here's the arc:
+Six patterns, applied to one morning's work. Here's the arc.
 
-- **09:00** — *"Research audio bible api options."* Fifteen minutes later I have a survey of seven options with verdicts.
-- **09:20** — Devil's-advocate prompt kills translation parity. Goal shrinks to *"one good audio source for every reference."*
-- **09:30** — *"What's the easiest path to listen to that specific verse?"* Answer: the ESV API.
-- **09:35** — Claude scaffolds `/api/verse-audio` as a near-copy of the existing `/api/verse` proxy. Inline `<audio>` lands in the verse panel. Crossway citation rendered alongside.
-- **09:45** — Push to prod. I test on my phone. Audio works.
-- **10:00** — Realisation: the same Crossway API key powers ESV *text* at `/passage/text/`. Half-hour upgrade adds ESV as a reading translation.
-- **10:30** — UX fixes: an "ESV Audio" pill so the audio-translation contract is visible; Originals mode auto-switches the translation to KJV (Strong's tagging is KJV-only, which made the toggle look broken on ESV); ESV text omits inline `[N]` verse markers because the panel header already names the range.
-- **11:00** — Same pattern extended to the Eagle Method book pages — ESV text and a *toggleable* audio player. Toggle defaults off, because the page shows five-plus verse cards in a grid and always-on audio would be visual noise.
-- **11:30** — README updated. CHANGELOG started, then backfilled to project inception.
-- **11:50** — Done. Ten PRs merged: [#16](https://github.com/adamswbrown/bible-tour/pull/16) through [#25](https://github.com/adamswbrown/bible-tour/pull/25).
+* **09:00.** *"Research audio bible api options."* Fifteen minutes later I have a survey of seven options with verdicts.
+* **09:20.** Devil's-advocate prompt kills translation parity. Goal shrinks to *"one good audio source for every reference."*
+* **09:30.** *"What's the easiest path to listen to that specific verse?"* Answer: the ESV API.
+* **09:35.** Claude scaffolds `/api/verse-audio` as a near-copy of the existing `/api/verse` proxy. Inline `<audio>` lands in the verse panel. Crossway citation rendered alongside.
+* **09:45.** Push to prod. I test on my phone. Audio works.
+* **10:00.** Realisation: the same Crossway API key powers ESV *text* at `/passage/text/`. Half-hour upgrade adds ESV as a reading translation.
+* **10:30.** UX fixes. An "ESV Audio" pill so the audio-translation contract is visible. Originals mode auto-switches the translation to KJV (Strong's tagging is KJV-only, which made the toggle look broken on ESV). ESV text omits inline `[N]` verse markers because the panel header already names the range.
+* **11:00.** Same pattern extended to the Eagle Method book pages. ESV text, plus a *toggleable* audio player. Toggle defaults off, because the page shows five-plus verse cards in a grid and always-on audio would be visual noise.
+* **11:30.** README updated. CHANGELOG started, then backfilled to project inception.
+* **11:50.** Done. Ten PRs merged: [#16](https://github.com/adamswbrown/bible-tour/pull/16) through [#25](https://github.com/adamswbrown/bible-tour/pull/25).
 
 Two new API routes. One new translation. One new toggle. Zero new dependencies. Two hours.
 
@@ -161,9 +161,9 @@ A few things I've come to believe after building most of an app this way.
 
 **Ship the docs in the same session as the code.** The model has the context; you have the momentum. Both fade fast.
 
-**Let the model run the release loop.** PRs, CI signals, merges, Vercel deploys — none of that needs to come back to you. Subscribe to the webhook activity, set the merge policy, stay in the strategic loop.
+**Let the model run the release loop.** PRs, CI signals, merges, Vercel deploys. None of that needs to come back to you. Subscribe to the webhook activity, set the merge policy, stay in the strategic loop.
 
-The meta-lesson: building with AI doesn't mean *automating the act of coding*. Anyone can prompt for code. It means **automating the engineering loop around the coding** — research, scoping, branching, CI, deploy, docs — so the only thing left for you to do is product judgement.
+The meta-lesson. Building with AI doesn't mean *automating the act of coding*. Anyone can prompt for code. It means **automating the engineering loop around the coding**: research, scoping, branching, CI, deploy, docs. The only thing left for you to do is product judgement.
 
 I made decisions for two hours this morning. Claude turned each decision into a shipped PR. That ratio is the real win, not the lines of code.
 

--- a/content/posts/shipping-from-my-phone/index.md
+++ b/content/posts/shipping-from-my-phone/index.md
@@ -1,0 +1,172 @@
+---
+title: "Ten PRs Before Lunch, From My Phone: The Prompting That Made It Reasonable"
+date: 2026-04-26T10:00:00Z
+draft: false
+hero: images/posts/shipping-from-my-phone/hero.svg
+description: "Two hours, ten merged PRs, no editor — just a phone, Claude Code, and six prompting patterns that turn the model from a coder into a release engineer."
+theme: Toha
+author:
+  name: Adam Brown
+  image: /images/author/adam.png
+image_alt: "A phone on a kitchen counter showing a GitHub PR list, coffee cup beside it"
+tags: ["agentic-coding", "claude-code", "prompting", "side-projects", "productivity"]
+categories: ["Projects", "Tech"]
+summary: "Two hours, ten merged PRs, no editor — just a phone, Claude Code, and six prompting patterns that turn the model from a coder into a release engineer."
+---
+
+[Tour of the Bible](https://bible-tour.vercel.app) is a small web app that walks you through every book of the Bible in about ninety minutes. It's a side-project. I am not a frontend engineer. Every line of code in it has been written in conversational sessions with [Claude Code](https://claude.com/claude-code) — the `claude/...` branch prefixes scattered through the [git history](https://github.com/adamswbrown/bible-tour) are the receipts.
+
+This morning I shipped ten pull requests from my phone, in about two hours. Per-verse ESV audio across two surfaces of the app. ESV added as a reading translation. A UX fix for the Strong's word-study mode. README updates. A CHANGELOG backfilled to the project's first commit. I never opened an editor.
+
+This post isn't really about what I shipped. It's about the *prompting* that made shipping it from a phone reasonable instead of ridiculous. Six patterns. They're worth more than any specific model or tool.
+
+## The setup: what is Claude actually doing?
+
+It's worth being explicit about the division of labour here, because the honest answer changes how you prompt.
+
+| My job | Claude's job |
+|---|---|
+| Product direction | Research |
+| Scope decisions | Implementation |
+| UX taste | Git mechanics, PR + CI orchestration |
+| Knowing what's worth building | Knowing how to build it |
+| Saying *"ship it"* | Saying *"here's what you'd give up"* |
+
+I make decisions; Claude implements them and pushes back when I'm wrong. That's the contract. Every pattern below is downstream of it.
+
+## Pattern 1 — Talk first, code last
+
+The first prompt I sent this morning was, in full, six words:
+
+> *"Research audio bible api options."*
+
+No spec. No solution. No file paths. Just a direction.
+
+Six words bought me a survey of every realistic option in the space: Bible Brain, API.Bible, the YouVersion developer API (which, as it turns out, has no audio endpoint at all — surprise), the eBible.org public-domain WEB recordings, the [Zaxser/verse-timings](https://github.com/Zaxser/verse-timings) forced-alignment data set, the Crossway ESV API. Each one came back with licensing terms, rate limits, and a verdict.
+
+If I'd opened with *"Add audio playback using the YouVersion API"* I'd have wasted half an hour discovering that endpoint doesn't exist. Open prompts produce better research than narrow ones, because they give the model permission to disagree with your premise *before* it touches any code.
+
+The cheapest line of code is the one you decided not to write.
+
+## Pattern 2 — Devil's advocate as a service
+
+This is the highest-leverage prompt I know. I'll give you the wording verbatim, because it matters:
+
+> *"Play devil's advocate around the idea of full translation support for the audio. If that's going to add a level of complexity I can't really support, convince me of my options."*
+
+I had a goal already: per-verse audio playback that matched whichever translation the user had picked — NIV, NIrV, NIVUK, KJV, WEB, ASV. It felt right. It mirrored the existing text experience. I half-believed in it.
+
+Five points came back, and the goal collapsed in the time it took to read them:
+
+1. **NIV/NIrV/NIVUK can't be embedded legally.** Biblica doesn't licence audio for third-party players at any free tier. Translation parity was already impossible — anything I built was going to be a hybrid the moment it touched the licensed translations.
+2. **Listeners don't pick translations the way readers do.** Translation choice is a *reading* decision. When you press play you mostly want a clear voice reading the words.
+3. **Audio is supplemental in this app, not the headline.** The product is a 90-minute reading checklist. Audio is a convenience layer on top.
+4. **Each translation is recurring engineering for marginal value.** Sourcing, licensing, hosting, maintaining when sources move — per-translation cost, marginal user value.
+5. **WEB and KJV cover ~90% of what a casual listener actually wants.**
+
+Days of integration work I won't do, plus a version of the feature that actually ships.
+
+The trick isn't asking the model to validate you. It's asking it to argue *against* you. *"Convince me of my options"* forces an opinionated counter-proposal instead of a polite pros-and-cons list. I now keep this prompt in my head for any feature larger than an afternoon's work. It catches premise-level mistakes that no amount of careful implementation can fix.
+
+## Pattern 3 — Make "easy" a first-class requirement
+
+I asked for the **easiest** option three times this morning, not the best. That word is doing a lot of work.
+
+When you ask for the *best* path you get a menu. When you ask for the *easiest* you get a recommendation. The constraint forces an opinion.
+
+Here's what "easiest" ruled out for me, in one move:
+
+- Forced alignment of chapter MP3s to extract per-verse clips. (Possible. A week of work.)
+- Pre-slicing 234 verse-clip MP3s and bundling them with the app. (Possible. A day of work plus storage.)
+- Running multiple audio sources behind a translation-aware switch. (Possible. Hybrid UX.)
+- Using browser SpeechSynthesis as a synthetic-voice fallback. (Possible. Sounds bad on Android.)
+
+The shortlist that survived: Crossway's ESV `/v3/passage/audio/?q=ref` endpoint. One HTTP call returns a 302 to an MP3. I forward that 302 to the browser, the `<audio>` tag follows it, Crossway's CDN serves the bytes, edge cache for seven days, done. Two hours of work.
+
+If "easy" hadn't been a first-class requirement, I'd have ended up with something more clever and less shipped.
+
+## Pattern 4 — Trust, but with named tradeoffs
+
+When Claude proposes a direction, the answer to *"want me to ship?"* is *"yes"* — but only because the proposal explicitly lists what I'd be giving up.
+
+Boiled down, the actual structure of a Claude proposal from this morning looked like this:
+
+> **Pick the ESV API.** Two-hour integration. Real human narration. Pattern matches your existing `/api/verse` proxy.
+>
+> **Tradeoffs:**
+> – Audio is *always ESV*, regardless of selected reading translation.
+> – Free for non-commercial only — needs Crossway approval if you ever monetise.
+> – Adds a Crossway API key to env vars (existing YouVersion key is already in there).
+
+I trust the implementation because the tradeoffs are named in advance. If they're hidden, I push back and ask for them.
+
+This is also how I catch over-engineering. If a proposal *doesn't* list any tradeoffs, that's usually a sign the model has reached for a heavier solution than the problem deserves. *"What does this give up?"* is a useful follow-up when none have been volunteered.
+
+## Pattern 5 — Mobile-first orchestration
+
+I was on my phone all morning. No editor. No localhost. No `npm run dev`. I could read GitHub diffs in a tiny font and that was about it. So the loop had to look different from how most people use Claude.
+
+The strategy was continuous deployment plus aggressive delegation. Every PR Claude opened got merged to `main` immediately. Vercel rebuilt production within a minute. I tested on the live site, on my phone, after each merge. Real users were potentially hitting features I'd shipped sixty seconds earlier. That feels reckless until you remember the alternative is testing nothing at all.
+
+This shifted Claude into a role most people don't ask it to play — **release engineer**. Branch from latest `main`. Commit with a sensible message. Push. Open a draft PR. Watch CI. Merge once green. Unsubscribe from the PR webhook. All autonomous. I'd authorise *"push to prod"* once and Claude would handle the mechanics every time afterwards.
+
+Claude Code's `subscribe_pr_activity` was load-bearing here. It let Claude react to every CI signal and review comment as it landed, without me babysitting GitHub. When Vercel posted a preview-ready comment, Claude triaged it ("informational only, no action") and moved on. When CI eventually goes red on something, Claude will investigate and propose a fix without me asking.
+
+The implication: Claude isn't just my pair-programmer in this setup. It's my CI dashboard, my code reviewer, and my deploy bot. That's the difference between *"AI helps me write code"* and *"AI runs the loop while I make decisions."*
+
+## Pattern 6 — Documentation as a deliverable
+
+I treat README and CHANGELOG updates as part of the feature, not a follow-up. Same-day docs are the only ones that ever happen on a side-project.
+
+This is also where AI assistants are uniquely good. They remember exactly what they just built. They have all the context. They'll write the README change *better* than you would, because they're working from the implementation, not from memory.
+
+Late in the session I asked Claude to backfill the CHANGELOG to project inception. That's hours of code archaeology — walking the git log, consolidating intermediate work commits, attributing changes to the right PRs, classifying everything as Added/Changed/Removed/Fixed. One prompt, one PR, done. I'd never have done it by hand.
+
+If your AI assistant is doing the implementation but not the docs, you're leaving a lot of value on the table.
+
+## The session, end to end
+
+Six patterns, applied to one morning's work. Here's the arc:
+
+- **09:00** — *"Research audio bible api options."* Fifteen minutes later I have a survey of seven options with verdicts.
+- **09:20** — Devil's-advocate prompt kills translation parity. Goal shrinks to *"one good audio source for every reference."*
+- **09:30** — *"What's the easiest path to listen to that specific verse?"* Answer: the ESV API.
+- **09:35** — Claude scaffolds `/api/verse-audio` as a near-copy of the existing `/api/verse` proxy. Inline `<audio>` lands in the verse panel. Crossway citation rendered alongside.
+- **09:45** — Push to prod. I test on my phone. Audio works.
+- **10:00** — Realisation: the same Crossway API key powers ESV *text* at `/passage/text/`. Half-hour upgrade adds ESV as a reading translation.
+- **10:30** — UX fixes: an "ESV Audio" pill so the audio-translation contract is visible; Originals mode auto-switches the translation to KJV (Strong's tagging is KJV-only, which made the toggle look broken on ESV); ESV text omits inline `[N]` verse markers because the panel header already names the range.
+- **11:00** — Same pattern extended to the Eagle Method book pages — ESV text and a *toggleable* audio player. Toggle defaults off, because the page shows five-plus verse cards in a grid and always-on audio would be visual noise.
+- **11:30** — README updated. CHANGELOG started, then backfilled to project inception.
+- **11:50** — Done. Ten PRs merged: [#16](https://github.com/adamswbrown/bible-tour/pull/16) through [#25](https://github.com/adamswbrown/bible-tour/pull/25).
+
+Two new API routes. One new translation. One new toggle. Zero new dependencies. Two hours.
+
+## What I take away from this
+
+A few things I've come to believe after building most of an app this way.
+
+**Constraints that ship beat goals that don't.** Translation parity was the ambitious goal. One translation that works everywhere was the shipped product. That's not a compromise; it's the right answer.
+
+**Free upgrades compound.** Once the Crossway key was in production for audio, ESV text was a half-hour add. Look for these wherever an integration's surface area is small.
+
+**Toggles are a real design tool, not a hedge.** The Eagle audio toggle isn't *"we couldn't decide"*. It's the right UX for a dense grid where always-on audio would clutter the page.
+
+**Open prompts produce better research than narrow ones.** *"Research X"* gives a survey. *"Implement X"* jumps straight to code and skips the part where you decide whether X is even the right thing.
+
+**Devil's advocate is the highest-ROI prompt I know.** The five points that killed my translation-parity goal would have cost me a week of work each on their own.
+
+**Tell the model what kind of answer you want.** *"Easiest."* *"Most architecturally consistent."* *"Convince me of my options."* *"Play devil's advocate."* Constraints like these are how you get opinionated output instead of waffle.
+
+**Treat the model like a senior collaborator, not a junior coder.** Hand it scope decisions and licence to push back. It will, if you let it. Most users don't.
+
+**Ship the docs in the same session as the code.** The model has the context; you have the momentum. Both fade fast.
+
+**Let the model run the release loop.** PRs, CI signals, merges, Vercel deploys — none of that needs to come back to you. Subscribe to the webhook activity, set the merge policy, stay in the strategic loop.
+
+The meta-lesson: building with AI doesn't mean *automating the act of coding*. Anyone can prompt for code. It means **automating the engineering loop around the coding** — research, scoping, branching, CI, deploy, docs — so the only thing left for you to do is product judgement.
+
+I made decisions for two hours this morning. Claude turned each decision into a shipped PR. That ratio is the real win, not the lines of code.
+
+---
+
+*[Tour of the Bible](https://bible-tour.vercel.app) is a fan-built companion to Matt Whitman's [Lightning-Fast Field Guide to the Bible](https://www.thetmbh.com/tourofthebible). Code at [github.com/adamswbrown/bible-tour](https://github.com/adamswbrown/bible-tour). Built by [Adam Brown](https://askadam.cloud/) and Claude.*

--- a/content/posts/shipping-from-my-phone/index.md
+++ b/content/posts/shipping-from-my-phone/index.md
@@ -16,15 +16,17 @@ summary: "Two hours, ten merged PRs, no editor. Just a phone, Claude Code, and t
 
 [Tour of the Bible](https://bible-tour.vercel.app) is a small web app that walks you through every book of the Bible in about ninety minutes. It's a side-project. I am not a frontend engineer. Every line of code in it has been written in conversational sessions with [Claude Code](https://claude.com/claude-code), and the `claude/...` branches scattered through the [git history](https://github.com/adamswbrown/bible-tour) are the receipts.
 
-This morning I shipped ten pull requests from my phone, in about two hours. Per-verse ESV audio across two surfaces of the app. ESV added as a reading translation. A UX fix for the Strong's word-study mode. A README rewrite. A CHANGELOG backfilled to the project's first commit. I never opened an editor.
+This morning I shipped ten pull requests from my phone, in about two hours, mostly from the kitchen between coffee refills. Per-verse ESV audio across two surfaces of the app. ESV added as a reading translation. A UX fix for the Strong's word-study mode. A README rewrite. A CHANGELOG backfilled to the project's first commit. I never opened an editor.
 
-The interesting part isn't *what* I shipped. It's how I prompted, and why prompting that way made phone-based shipping reasonable instead of ridiculous. Six habits. They matter more than any particular model or tool.
+I should be honest up front: this morning went unusually cleanly. Some sessions get knotted up and I have to reset the conversation and start the bit again. Today nothing got knotted. But the *prompting* was the same prompting I always do, and it's the prompting (more than the model, more than the tool) that makes phone-based shipping reasonable instead of ridiculous. Six habits. None of them are about typing faster.
 
 ## What is Claude actually doing here?
 
 Worth being explicit about who's doing what, because the honest answer changes how you prompt.
 
 I'm doing product direction, scope decisions, and UX taste. I'm the one who knows what's worth building and the one who eventually says "ship it". Claude is doing research, implementation, the mechanics of git and PRs and CI, and (when I let it) telling me what I'd be giving up before I commit to anything. I make the calls. Claude does the work and pushes back when I'm wrong. That's the whole contract, and the rest of this post falls out of it.
+
+Most of what I see go badly with these tools is people getting that boundary wrong in either direction: micromanaging implementation, or handing over the product decisions. Both feel productive in the moment. Neither ends well.
 
 ## 1. Talk first, code last
 
@@ -36,7 +38,7 @@ No spec. No solution. No file paths. Just a direction.
 
 Six words bought me a survey of every realistic option in the space. Bible Brain. API.Bible. The YouVersion developer API, which, as it turns out, has no audio endpoint at all (mild surprise, that one). The eBible.org public-domain WEB recordings. The [Zaxser/verse-timings](https://github.com/Zaxser/verse-timings) forced-alignment dataset. Crossway's ESV API. Each came back with licensing terms, rate limits, and a verdict.
 
-If I'd opened with *"Add audio playback using the YouVersion API"* I'd have spent half an hour discovering that the endpoint doesn't exist. Open prompts produce better research than narrow ones, because they give the model permission to disagree with your premise before it touches any code.
+If I'd opened with *"Add audio playback using the YouVersion API"* I'd have spent half an hour discovering that the endpoint doesn't exist, probably with a half-built proxy route already on the branch. Open prompts produce better research than narrow ones, because they give the model permission to disagree with your premise before it touches any code.
 
 The cheapest line of code is the one you decided not to write.
 
@@ -46,7 +48,7 @@ This is the prompt I get the most out of, and the wording matters, so I'll give 
 
 > *"Play devil's advocate around the idea of full translation support for the audio. If that's going to add a level of complexity I can't really support, convince me of my options."*
 
-I had a goal already. Per-verse audio playback that matched whichever translation the user had picked: NIV, NIrV, NIVUK, KJV, WEB, ASV. It felt right. It mirrored the existing text experience. I half-believed in it.
+I had a goal already. Per-verse audio playback that matched whichever translation the user had picked: NIV, NIrV, NIVUK, KJV, WEB, ASV. It felt right. It mirrored the existing text experience. I half-believed in it. Half-believing is the dangerous bit, because half-belief is enough to start building.
 
 Five points came back, and the goal collapsed in the time it took to read them.
 
@@ -62,7 +64,7 @@ The trick isn't asking the model to validate you. It's asking it to argue agains
 
 ## 3. Make "easy" a first-class requirement
 
-I asked for the *easiest* option three times this morning, not the best. That word does a lot of work.
+I asked for the *easiest* option three times this morning, not the best. "Easy" isn't a word engineers love. It feels like you're asking for the cheap version of the thing. But if you don't say it out loud, you don't get it.
 
 Ask for the *best* path and you get a menu. Ask for the *easiest* and you get a recommendation. The constraint forces an opinion.
 
@@ -92,13 +94,13 @@ Boiled down, the actual structure of a Claude proposal from this morning looked 
 
 I trust the implementation because the tradeoffs are named in advance. If they're hidden, I push back and ask for them.
 
-It's also how I catch over-engineering. If a proposal *doesn't* list any tradeoffs, that's usually a sign the model has reached for a heavier solution than the problem deserves. *"What does this give up?"* is a good follow-up when nothing has been volunteered.
+It's also how I catch over-engineering, which is honestly the failure mode I see most often with this stuff. If a proposal *doesn't* list any tradeoffs, the model has usually reached for a heavier solution than the problem deserves. Ask for an email; it proposes a queue. Ask for a form; it suggests an architecture. *"What does this give up?"* is a good follow-up when nothing has been volunteered.
 
 ## 5. Mobile-first orchestration
 
 I was on my phone all morning. No editor. No localhost. No `npm run dev`. I could read GitHub diffs in a tiny font and that was about it. So the loop had to look different from how most people use Claude.
 
-The strategy was continuous deployment plus aggressive delegation. Every PR Claude opened got merged to `main` immediately. Vercel rebuilt production within a minute. I tested on the live site, on my phone, after each merge. Real users were potentially hitting features I'd shipped sixty seconds earlier. That feels reckless until you remember the alternative is testing nothing at all.
+The strategy was continuous deployment plus aggressive delegation. Every PR Claude opened got merged to `main` immediately. Vercel rebuilt production within a minute. I tested on the live site, on my phone, after each merge. Real users were potentially hitting features I'd shipped sixty seconds earlier. That feels reckless, and there's a small wince every time. But the alternative on a phone is testing nothing at all, and I'd rather a real user catch a bug in a free side-project than ship a wall of unverified code at the end of the morning.
 
 This put Claude in a role most people don't ask it to play, which is release engineer. Branch from latest `main`. Commit with a sensible message. Push. Open a draft PR. Watch CI. Merge once green. Unsubscribe from the PR webhook. All autonomous. I'd authorise *"push to prod"* once and Claude would handle the mechanics every time afterwards.
 
@@ -108,7 +110,7 @@ Which means Claude wasn't just my pair-programmer in this setup. It was my CI da
 
 ## 6. Documentation as a deliverable
 
-I treat README and CHANGELOG updates as part of the feature, not a follow-up. Same-day docs are the only ones that ever happen on a side-project.
+I treat README and CHANGELOG updates as part of the feature, not a follow-up. Same-day docs are the only ones that ever happen on a side-project; everyone who has ever said "I'll come back and write that up later" is lying to themselves, and I include myself in that.
 
 This is also where AI assistants are unfairly good. They remember exactly what they just built. They have all the context. They will write the README change *better* than you would, because they're working from the implementation rather than from memory.
 
@@ -148,7 +150,9 @@ And let the model run the release loop. PRs, CI signals, merges, Vercel deploys;
 
 The thing I've come to believe, after a few months of building this way, is that building with AI doesn't really mean *automating the act of coding*. Anyone can prompt for code. It means automating the engineering loop *around* the coding (research, scoping, branching, CI, deploy, docs) so the only thing left for you to do is product judgement.
 
-I made decisions for two hours this morning. Claude turned each decision into a shipped PR. That ratio is the win, not the line count.
+That's also why phone-shipping works at all. You can't write code on a phone, but you can absolutely make decisions on a phone, and on a morning like this one, decisions are the only thing the work actually needs from me.
+
+I made decisions for two hours this morning. Claude turned each one into a shipped PR. That ratio is the win, not the line count.
 
 ---
 


### PR DESCRIPTION
## Summary
- New blog post at `content/posts/shipping-from-my-phone/index.md` covering the six prompting patterns behind shipping ten PRs from a phone in two hours.
- Humanised from a scaffold to match the existing voice (Tour of the Bible, consultant's-revolution): British spelling, short paragraphs, em dashes, italics for emphasis, "named tradeoffs" framing, opinionated closer.
- Front matter mirrors the other `building-*` and projects posts (Toha theme, author block, hero path, tags/categories).

## Test plan
- [ ] `hugo server -w` renders the post without errors
- [ ] Post card and detail page look right in light + dark modes
- [ ] All external links resolve (bible-tour, repo, PRs #16–#25, Crossway/eBible references)
- [ ] Hero image at `assets/images/posts/shipping-from-my-phone/hero.svg` exists or falls back gracefully

https://claude.ai/code/session_01DLhFYE3f3gyNGUmUkva5yk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLhFYE3f3gyNGUmUkva5yk)_