### PR TITLE
Fix shipping post date so it shows on the live site

### DIFF
--- a/content/posts/shipping-from-my-phone/index.md
+++ b/content/posts/shipping-from-my-phone/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Ten PRs Before Lunch, From My Phone"
-date: 2026-04-26T10:00:00Z
+date: 2026-04-26T08:00:00Z
 draft: false
 hero: images/posts/shipping-from-my-phone/hero.svg
 description: "Two hours, ten merged PRs, no editor. Just a phone, Claude Code, and the prompting habits that turn the model from a coder into a release engineer."


### PR DESCRIPTION
## Summary
- The "Ten PRs Before Lunch" post was dated `2026-04-26T10:00:00Z`, but PR #10 merged at `09:47:40Z`. Hugo's `buildFuture` defaults to `false`, so when the build ran the post was ~12 minutes in the future and got silently dropped from the build output.
- Backdated the post to `08:00:00Z` (clearly in the past) so the next deploy picks it up. Same fix pattern as commit 0ad2eb8 for the Consultant's Revolution post.

## Test plan
- [ ] Merge triggers the `Deploy to Github Pages` workflow
- [ ] Post appears on https://adambrown.cloud after the build completes
- [ ] Post appears at https://adambrown.cloud/posts/shipping-from-my-phone/
- [ ] Listed on the home page card grid

https://claude.ai/code/session_01DLhFYE3f3gyNGUmUkva5yk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLhFYE3f3gyNGUmUkva5yk)_