### PR TITLE
Add post-date rule to CLAUDE.md to prevent future-dated posts being hidden

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Create `content/posts/[slug]/index.md`:
 ```yaml
 ---
 title: "Post Title"
-date: 2026-01-31T10:00:00Z
+date: 2026-01-31T08:00:00Z
 draft: false
 hero: images/posts/[slug]/hero.svg
 description: "Short description for SEO and cards"
@@ -66,6 +66,8 @@ categories: ["Category"]
 
 Content goes here...
 ```
+
+**IMPORTANT — post date must be in the past at build time.** Hugo's `buildFuture` is unset (defaults to `false`), so any post dated even a minute in the future is silently dropped from the build. When publishing today, set the date to early-morning UTC (e.g. `T08:00:00Z`) — never the current time, and never round numbers like `T10:00:00Z` that risk being ahead of the build server. Both previous publishing incidents on this blog (commits `0ad2eb8` and `4267430`) were caused by this. If a post you just merged isn't appearing on the live site, this is the first thing to check.
 
 ### Hero Images
 


### PR DESCRIPTION
## Summary
- Adds a callout under the "New Blog Post" section explaining that Hugo's `buildFuture` is unset (defaults to `false`), so any post dated even a minute in the future at build time gets silently dropped.
- Updates the example front matter from `T10:00:00Z` to `T08:00:00Z` so the documented default is safe — both prior incidents (`0ad2eb8`, `4267430`) used round-number times that were ahead of the merge build.
- Cites both prior commits so the next person who hits "post not showing up" can find the cause fast.

## Test plan
- [ ] Read CLAUDE.md and confirm the callout reads cleanly
- [ ] Confirm the next post created from this template uses the `T08:00:00Z` date pattern

https://claude.ai/code/session_01DLhFYE3f3gyNGUmUkva5yk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLhFYE3f3gyNGUmUkva5yk)_