### PR TITLE
Add daily build cron and follow-up post (Constrained by Time, Not Ability)

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -1,10 +1,14 @@
 name: Deploy to Github Pages
 
-# run when a commit is pushed to "source" branch
+# run when a commit is pushed to "source" branch, and once a day so
+# future-dated posts auto-publish on their scheduled morning
 on:
   push:
     branches:
     - main
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/content/posts/constrained-by-time-not-ability/index.md
+++ b/content/posts/constrained-by-time-not-ability/index.md
@@ -1,0 +1,37 @@
+---
+title: "Constrained by Time, Not Ability"
+date: 2026-04-27T08:00:00Z
+draft: false
+hero: images/posts/constrained-by-time-not-ability/hero.svg
+description: "A friend pushed back on yesterday's post. The framing made Claude the smart one and me the person pointing at things, and that isn't true. Here's the version I should have written."
+theme: Toha
+author:
+  name: Adam Brown
+  image: /images/author/adam.png
+image_alt: "An hourglass running out, with a notebook of ideas waiting beside it"
+tags: ["agentic-coding", "claude-code", "framing", "consulting"]
+categories: ["Projects", "Tech"]
+summary: "A friend pushed back on yesterday's post. The framing made Claude the smart one and me the person pointing at things, and that isn't true. Here's the version I should have written."
+---
+
+[Yesterday's post](/posts/shipping-from-my-phone/) had a section called *what is Claude actually doing here*, with a tidy little table splitting the labour between me and the model. A friend read the post and pushed back on it.
+
+> "At first read, it feels like you're trying to devalue the work you do through Claude and make it seem like Claude is the smart one and you just have 'ideas'. I would've preferred the opposite perspective. Claude, a tool, brings out in you and to life ideas you have that are constrained by time, not ability."
+
+He's right. The table makes Claude the intelligent one and me the person pointing at things, and that isn't true.
+
+What stings is that I'd already written the better version. In [Agentic Coding Is the Consultant's Revolution](/posts/consultants-revolution/) I argued that the people who gain the most from these tools are the ones who *saw problems and couldn't build solutions*, the consultants and operators and analysts and church tech teams whose ideas died in the gap between "I can see how this should work" and "I can afford the weeks it would take to build it". The ideas were always there. The construction cost was the blocker.
+
+Yesterday I let that framing slip into something weaker, so here's the version I should have written.
+
+I have ideas all the time. So does everyone. Most of mine used to die in the gap, the same way yours probably do. Tour of the Bible lived in my head for months before agentic coding made it tractable. Meeting Reminder existed because I have ADHD and miss meetings, not because I had a Swift architecture worked out for it. ProPresenter Lyric Export existed because a small group of church tech volunteers needed it on a Sunday morning, not because I'd been holding out for the right TypeScript abstraction. None of those projects were waiting on the *right idea*. They were waiting on the cost of building dropping to something I could actually afford to spend.
+
+What Claude does is collapse that cost. It is not the source of the taste, the scope decisions, the UX calls, or the choice of whether the feature is worth building at all. Those were mine. They were always mine. They would have stayed in my head forever if the construction cost hadn't dropped close to zero.
+
+The right reading of yesterday's table isn't *Adam has ideas, Claude has the skills*. It's: same ideas as before, time constraint removed.
+
+That's the difference between *AI is the smart one* and *AI is leverage*. The first framing is wrong, and it's wrong in a way I should be careful about, because it's the framing that makes people both more frightened of these tools than they need to be (the machine is taking over) and more credulous of them than they ought to be (the machine knows best). Neither is true. The machine is fast. That's the part of the story that actually changed.
+
+The constraint that's been removed is time. Not ability.
+
+Thanks for the push.


### PR DESCRIPTION
## Summary

Two changes, intentionally bundled because the second depends on the first.

**1. Daily build cron.** The deploy workflow only ran on push to `main`, which meant a post dated for tomorrow merged today would never appear, because nothing triggers a rebuild after the date passes. Adds a `schedule: cron: '0 9 * * *'` trigger so the site rebuilds every morning at 09:00 UTC and picks up overnight-dated posts. Also adds `workflow_dispatch` so you can trigger a manual rebuild from the Actions tab if needed.

Pairs with the post-date convention that posts are dated for `T08:00:00Z` (so the 09:00 cron is comfortably after).

**2. Follow-up post: *Constrained by Time, Not Ability*.** Dated `2026-04-27T08:00:00Z`. Responds to a private DM critique of yesterday's "what is Claude actually doing" section, which a friend pointed out frames Claude as the smart one and Adam as just an idea person. Reframes Claude as a time-collapser rather than an intelligence source, in line with the thesis from `/posts/consultants-revolution/`.

The friend is referenced anonymously. If permission to credit by name comes through, change "A friend" to the name and ship a one-line follow-up commit.

## Test plan
- [ ] Workflow YAML still parses (Actions tab shows the next scheduled run)
- [ ] Post renders cleanly in `hugo server -w`
- [ ] When merged today, the post does *not* appear on the live site (date is in the future)
- [ ] At ~09:00 UTC tomorrow, the scheduled rebuild runs and the post appears at https://adambrown.cloud/posts/constrained-by-time-not-ability/
- [ ] Internal links to `/posts/shipping-from-my-phone/` and `/posts/consultants-revolution/` resolve

https://claude.ai/code/session_01DLhFYE3f3gyNGUmUkva5yk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLhFYE3f3gyNGUmUkva5yk)_