### PR TITLE
Trigger Netlify rebuilds from the scheduled cron via empty commit

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -13,9 +13,22 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     # checkout to the commit that has been pushed
     - uses: actions/checkout@v4
+
+    # On scheduled / manual runs, push an empty commit to main so
+    # Netlify (which only builds on push, not on cron) rebuilds too.
+    # GH Pages keeps building from this same workflow run.
+    - name: Trigger Netlify rebuild via empty commit
+      if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git commit --allow-empty -m "chore: scheduled rebuild for date-gated posts"
+        git push origin main
 
     - name: Setup Hugo
       uses: peaceiris/actions-hugo@v3


### PR DESCRIPTION
## Summary
- The daily cron added in PR #13 only rebuilt **GitHub Pages** (adambrown.cloud). Netlify (askadam.cloud) only builds on `push` events, so today's scheduled run never reached it and the *Constrained by Time, Not Ability* post didn't appear there.
- On `schedule` and `workflow_dispatch` triggers, the workflow now pushes an empty commit to `main` before the build steps run. Netlify's GitHub integration sees the push and rebuilds; GitHub Pages continues to deploy from the same workflow run as before.
- The empty-commit step is gated behind `github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'`, so push-triggered runs skip it. No infinite loop (and `GITHUB_TOKEN` pushes don't re-trigger workflows anyway, which is the safety net behind the safety net).
- Job gets `permissions: contents: write` to allow the empty-commit push.

## Tradeoff (for the record)
- One empty commit per day will accumulate in the `main` history. Acceptable price for "both deployments stay in sync without managing a Netlify build hook secret."

## Test plan
- [ ] Manual `workflow_dispatch` run pushes an empty commit, deploys to gh-pages, *and* shows a fresh Netlify build under https://app.netlify.com/projects/askadamcloud
- [ ] Tomorrow's 09:00 UTC scheduled run does the same automatically
- [ ] Push-triggered builds (e.g. merging this PR) do **not** push an empty commit
- [ ] The post at https://askadam.cloud/posts/constrained-by-time-not-ability/ becomes visible after the next scheduled or dispatched run

https://claude.ai/code/session_01DLhFYE3f3gyNGUmUkva5yk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLhFYE3f3gyNGUmUkva5yk)_